### PR TITLE
Add a tooltip and use new way to copy text

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,20 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Mocking Text Generator</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
     <h1>mOcKiNg tExT</h1>
     <div>
         <textarea name="text-input" id="text-input" style="width:100%;height: 40vh" placeholder="Type regular message here"></textarea>
         <textarea name="mocking-text" id="mocking-text" style="width:100%;height: 40vh" placeholder="sArCaStIc mEsSaGe sHoWs uP HeRe" readonly></textarea><br>
-        <button onclick="copyText()">Copy text</button>
+        <div class="tooltip">
+            <button onclick="copyTextClick()" onmouseout="copyTextOut()" id="button-copy-text">
+                <span class="tooltiptext" id="tooltip-copy-text">Copy mock text to clipboard</span>
+                Copy text
+            </button>
+        </div>
     </div>
+    <script src="index.js"></script>
 </body>
-<script src="index.js"></script>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var textInput = document.getElementById("text-input");
-var mockingText = document.getElementById("mocking-text")
+var mockingText = document.getElementById("mocking-text");
+var buttonCopyText = document.getElementById("button-copy-text");
+var tooltipCopyText = document.getElementById("tooltip-copy-text");
 
 function mockingConverter(str) {
 	const strArray = str.toLowerCase().split("");
@@ -12,8 +14,14 @@ textInput.onkeyup = function(e) {
     mockingText.innerText = mockingConverter(input)
 };
 
-function copyText() {
+function copyTextClick() {
+    // Implementation copied from here: https://www.w3schools.com/howto/howto_js_copy_clipboard.asp
     mockingText.select();
-    document.execCommand("copy");
-    alert("Copied text");
+    mockingText.setSelectionRange(0, 99999);
+    navigator.clipboard.writeText(mockingText.value);
+    tooltipCopyText.innerHTML = "Copied";
   }
+
+function copyTextOut() {
+    tooltipCopyText.innerHTML = "Copy mock text to clipboard";
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,37 @@
+.tooltip {
+    position: relative;
+    display: inline-block;
+  }
+  
+  .tooltip .tooltiptext {
+    visibility: hidden;
+    width: 140px;
+    background-color: #555;
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+    padding: 5px;
+    position: absolute;
+    z-index: 1;
+    bottom: 150%;
+    left: -9%;
+    margin-left: 0;
+    opacity: 0;
+    transition: opacity 0.3s;
+  }
+  
+  .tooltip .tooltiptext::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: #555 transparent transparent transparent;
+  }
+  
+  .tooltip:hover .tooltiptext {
+    visibility: visible;
+    opacity: 1;
+  }


### PR DESCRIPTION
- The currently used method `document.execCommand` has been deprecated and will not be supported in future versions of browsers: https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
- Also added a tooltip